### PR TITLE
hazkey-serverのテストを現行プロトコルへ移植

### DIFF
--- a/hazkey-server/Tests/hazkey-server/base.swift
+++ b/hazkey-server/Tests/hazkey-server/base.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import hazkey-server
+@testable import hazkey_server
 
 class BaseHazkeyServerTestCase: XCTestCase {
   var client: HazkeyServerClient!
@@ -43,10 +43,10 @@ class BaseHazkeyServerTestCase: XCTestCase {
 
   // Helper method for sending queries with better error reporting
   func sendQuery(
-    _ query: Hazkey_Commands_QueryData,
+    _ query: Hazkey_RequestEnvelope,
     file: StaticString = #file,
     line: UInt = #line
-  ) throws -> Hazkey_Commands_ResultData {
+  ) throws -> Hazkey_ResponseEnvelope {
     do {
       return try client.sendQuery(query)
     } catch {

--- a/hazkey-server/Tests/hazkey-server/candidate.swift
+++ b/hazkey-server/Tests/hazkey-server/candidate.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 final class CandidateTests: BaseHazkeyServerTestCase {
 
@@ -13,10 +13,8 @@ final class CandidateTests: BaseHazkeyServerTestCase {
       candidatesResponse.status, .success, "Getting candidates should succeed even with empty input"
     )
 
-    if case .candidates(let candidatesResult) = candidatesResponse.props {
-      XCTAssertTrue(
-        candidatesResult.candidates.isEmpty || candidatesResult.candidates.count > 0,
-        "Should return candidates array (empty or populated)")
+    if case .candidates(let candidatesResult) = candidatesResponse.payload {
+      XCTAssertTrue(candidatesResult.candidates.isEmpty)
     } else {
       XCTFail("Response should contain candidates")
     }
@@ -28,12 +26,12 @@ final class CandidateTests: BaseHazkeyServerTestCase {
     let inputResponse = try sendQuery(inputQuery)
     XCTAssertEqual(inputResponse.status, .success)
 
-    let candidatesQuery = QueryDataBuilder.getCandidates(nBest: 5)
+    let candidatesQuery = QueryDataBuilder.getCandidates()
     let candidatesResponse = try sendQuery(candidatesQuery)
 
     XCTAssertEqual(candidatesResponse.status, .success, "Getting candidates should succeed")
 
-    if case .candidates(let candidatesResult) = candidatesResponse.props {
+    if case .candidates(let candidatesResult) = candidatesResponse.payload {
       XCTAssertFalse(
         candidatesResult.candidates.isEmpty, "Should return some candidates for hiragana input")
 
@@ -46,19 +44,21 @@ final class CandidateTests: BaseHazkeyServerTestCase {
     }
   }
 
-  func testGetCandidatesWithNBestLimit() throws {
+  func testGetCandidatesUsesConfiguredPageSize() throws {
+    let configResponse = try sendQuery(QueryDataBuilder.setConfig())
+    XCTAssertEqual(configResponse.status, .success)
+
     let inputQuery = QueryDataBuilder.inputText("あ")
     let inputResponse = try sendQuery(inputQuery)
     XCTAssertEqual(inputResponse.status, .success)
 
-    let nBest: Int32 = 3
-    let candidatesQuery = QueryDataBuilder.getCandidates(nBest: nBest)
+    let candidatesQuery = QueryDataBuilder.getCandidates()
     let candidatesResponse = try sendQuery(candidatesQuery)
 
     XCTAssertEqual(candidatesResponse.status, .success)
 
-    if case .candidates(let candidatesResult) = candidatesResponse.props {
-      XCTAssertTrue(candidatesResult.candidates.count >= 0, "Should return candidates array")
+    if case .candidates(let candidatesResult) = candidatesResponse.payload {
+      XCTAssertEqual(candidatesResult.pageSize, 9)
     } else {
       XCTFail("Response should contain candidates")
     }
@@ -69,14 +69,13 @@ final class CandidateTests: BaseHazkeyServerTestCase {
     let inputResponse = try sendQuery(inputQuery)
     XCTAssertEqual(inputResponse.status, .success)
 
-    let candidatesQuery = QueryDataBuilder.getCandidates(isPredictMode: true)
+    let candidatesQuery = QueryDataBuilder.getCandidates(isSuggest: true)
     let candidatesResponse = try sendQuery(candidatesQuery)
 
     XCTAssertEqual(candidatesResponse.status, .success, "Predict mode should work")
 
-    if case .candidates(let candidatesResult) = candidatesResponse.props {
-      // In predict mode, we might get prediction candidates
-      XCTAssertTrue(candidatesResult.candidates.count >= 0, "Should return candidates array")
+    if case .candidates(let candidatesResult) = candidatesResponse.payload {
+      XCTAssertFalse(candidatesResult.candidates.isEmpty)
     } else {
       XCTFail("Response should contain candidates")
     }

--- a/hazkey-server/Tests/hazkey-server/composingTextExtension.swift
+++ b/hazkey-server/Tests/hazkey-server/composingTextExtension.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 final class TextInputTests: BaseHazkeyServerTestCase {
 
@@ -13,7 +13,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString(charType: .hiragana)
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "あ", "Should return the input hiragana character")
+    XCTAssertEqual(stringResponse.text, "あ", "Should return the input hiragana character")
   }
 
   func testMultipleCharacterInput() throws {
@@ -28,11 +28,17 @@ final class TextInputTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString(charType: .hiragana)
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "あいう", "Should concatenate multiple hiragana characters")
+    XCTAssertEqual(stringResponse.text, "あいう", "Should concatenate multiple hiragana characters")
   }
 
   func testDirectInput() throws {
-    let inputQuery = QueryDataBuilder.inputText("A", isDirect: true)
+    XCTAssertEqual(
+      try sendQuery(QueryDataBuilder.modifierEvent(type: .shift, event: .press)).status,
+      .success)
+    XCTAssertEqual(
+      try sendQuery(QueryDataBuilder.modifierEvent(type: .shift, event: .release)).status,
+      .success)
+    let inputQuery = QueryDataBuilder.inputText("A")
     let inputResponse = try sendQuery(inputQuery)
     XCTAssertEqual(inputResponse.status, .success, "Direct input should succeed")
 
@@ -40,7 +46,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
     XCTAssertEqual(
-      stringResponse.result, "A", "Direct input should preserve the original character")
+      stringResponse.text, "A", "Direct input should preserve the original character")
   }
 
   func testEmptyStringInput() throws {
@@ -54,7 +60,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
 
   func testNumericInputWithFullwidthConfiguration() throws {
     // Set configuration for fullwidth numbers
-    let configQuery = QueryDataBuilder.setConfig(numberFullwidth: 1)
+    let configQuery = QueryDataBuilder.setConfig(numberFullwidth: true)
     let configResponse = try sendQuery(configQuery)
     XCTAssertEqual(configResponse.status, .success)
 
@@ -70,7 +76,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString(charType: .hiragana)
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "１", "Only first character should be processed")
+    XCTAssertEqual(stringResponse.text, "１", "Only first character should be processed")
   }
 
   func testCharacterTypeConversion() throws {
@@ -79,7 +85,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
     XCTAssertEqual(inputResponse.status, .success)
 
     // Test different character type outputs
-    let testCases: [(Hazkey_Commands_QueryData.GetComposingStringProps.CharType, String)] = [
+    let testCases: [(Hazkey_Commands_GetComposingString.CharType, String)] = [
       (.hiragana, "あ"),
       (.katakanaFull, "ア"),
       (.katakanaHalf, "ｱ"),
@@ -90,7 +96,7 @@ final class TextInputTests: BaseHazkeyServerTestCase {
       let stringResponse = try sendQuery(getStringQuery)
       XCTAssertEqual(stringResponse.status, .success)
       XCTAssertEqual(
-        stringResponse.result, expected,
+        stringResponse.text, expected,
         "Character type \(charType) should return \(expected)")
     }
   }

--- a/hazkey-server/Tests/hazkey-server/config.swift
+++ b/hazkey-server/Tests/hazkey-server/config.swift
@@ -1,17 +1,13 @@
 import Foundation
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 final class ConfigurationTests: BaseHazkeyServerTestCase {
   func testSetCustomConfiguration() throws {
     let query = QueryDataBuilder.setConfig(
-      commaStyle: 1,
-      numberFullwidth: 1,
-      periodStyle: 2,
-      spaceFullwidth: 1,
-      symbolFullwidth: 1,
-      tenCombining: 1,
+      numberFullwidth: true,
+      symbolFullwidth: true,
       zenzaiEnabled: true,
       zenzaiInferLimit: 5
     )
@@ -24,13 +20,23 @@ final class ConfigurationTests: BaseHazkeyServerTestCase {
     XCTAssertTrue(
       response.errorMessage.isEmpty,
       "Error message should be empty on success")
+
+    let currentConfigResponse = try sendQuery(QueryDataBuilder.getConfig())
+    XCTAssertEqual(currentConfigResponse.status, .success)
+    guard case .currentConfig(let currentConfig) = currentConfigResponse.payload,
+      let profile = currentConfig.profiles.first
+    else {
+      return XCTFail("Response should contain the current profile")
+    }
+    XCTAssertTrue(profile.zenzaiEnable)
+    XCTAssertEqual(profile.zenzaiInferLimit, 5)
   }
 
   func testConfigurationPersistence() throws {
     // Set a custom configuration
     let customConfig = QueryDataBuilder.setConfig(
-      numberFullwidth: 1,
-      symbolFullwidth: 1
+      numberFullwidth: true,
+      symbolFullwidth: true
     )
     let configResponse = try sendQuery(customConfig)
     XCTAssertEqual(configResponse.status, .success)
@@ -51,7 +57,7 @@ final class ConfigurationTests: BaseHazkeyServerTestCase {
 
     // With fullwidth numbers enabled, "1" should become "１"
     XCTAssertEqual(
-      stringResponse.result, "１",
+      stringResponse.text, "１",
       "Number should be converted to fullwidth when numberFullwidth is enabled")
   }
 }

--- a/hazkey-server/Tests/hazkey-server/error.swift
+++ b/hazkey-server/Tests/hazkey-server/error.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 final class ErrorHandlingTests: BaseHazkeyServerTestCase {
 
@@ -12,11 +12,7 @@ final class ErrorHandlingTests: BaseHazkeyServerTestCase {
     XCTAssertEqual(inputResponse.status, .success)
 
     // Try to get composing string with invalid character type
-    var query = Hazkey_Commands_QueryData()
-    query.function = .getComposingString
-    query.getComposingString = Hazkey_Commands_QueryData.GetComposingStringProps.with {
-      $0.charType = .UNRECOGNIZED(999)  // Invalid char type
-    }
+    let query = QueryDataBuilder.getComposingString(charType: .UNRECOGNIZED(999))
 
     let response = try sendQuery(query)
     XCTAssertEqual(response.status, .failed, "Invalid character type should result in failure")
@@ -44,7 +40,7 @@ final class ErrorHandlingTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString()
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "", "New instance should have empty composing text")
+    XCTAssertEqual(stringResponse.text, "", "New instance should have empty composing text")
   }
 
   func testLargeInputString() throws {
@@ -59,6 +55,6 @@ final class ErrorHandlingTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString()
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "あ", "Should only process first character")
+    XCTAssertEqual(stringResponse.text, "あ", "Should only process first character")
   }
 }

--- a/hazkey-server/Tests/hazkey-server/integration.swift
+++ b/hazkey-server/Tests/hazkey-server/integration.swift
@@ -1,15 +1,15 @@
 import Foundation
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 final class IntegrationTests: BaseHazkeyServerTestCase {
 
   func testCompleteInputWorkflow() throws {
     // 1. Set custom configuration
     let configQuery = QueryDataBuilder.setConfig(
-      numberFullwidth: 1,
-      symbolFullwidth: 1
+      numberFullwidth: true,
+      symbolFullwidth: true
     )
     let configResponse = try sendQuery(configQuery)
     XCTAssertEqual(configResponse.status, .success)
@@ -31,14 +31,14 @@ final class IntegrationTests: BaseHazkeyServerTestCase {
     let getStringQuery = QueryDataBuilder.getComposingString(charType: .hiragana)
     let stringResponse = try sendQuery(getStringQuery)
     XCTAssertEqual(stringResponse.status, .success)
-    XCTAssertEqual(stringResponse.result, "こんにちは", "Should compose complete hiragana string")
+    XCTAssertEqual(stringResponse.text, "こんにちは", "Should compose complete hiragana string")
 
     // 5. Get candidates
     let candidatesQuery = QueryDataBuilder.getCandidates()
     let candidatesResponse = try sendQuery(candidatesQuery)
     XCTAssertEqual(candidatesResponse.status, .success)
 
-    if case .candidates(let candidatesResult) = candidatesResponse.props {
+    if case .candidates(let candidatesResult) = candidatesResponse.payload {
       XCTAssertFalse(candidatesResult.candidates.isEmpty, "Should return candidates for 'こんにちは'")
 
       // Check if we get "こんにちは" or "今日は" as candidates
@@ -54,8 +54,8 @@ final class IntegrationTests: BaseHazkeyServerTestCase {
   func testNumberAndSymbolConversion() throws {
     // Configure for fullwidth conversion
     let configQuery = QueryDataBuilder.setConfig(
-      numberFullwidth: 1,
-      symbolFullwidth: 1
+      numberFullwidth: true,
+      symbolFullwidth: true
     )
     let configResponse = try sendQuery(configQuery)
     XCTAssertEqual(configResponse.status, .success)
@@ -72,7 +72,7 @@ final class IntegrationTests: BaseHazkeyServerTestCase {
     let getNumberQuery = QueryDataBuilder.getComposingString()
     let numberStringResponse = try sendQuery(getNumberQuery)
     XCTAssertEqual(numberStringResponse.status, .success)
-    XCTAssertEqual(numberStringResponse.result, "５", "Number should be converted to fullwidth")
+    XCTAssertEqual(numberStringResponse.text, "５", "Number should be converted to fullwidth")
   }
 
   func testMultipleSessionsSequentially() throws {
@@ -94,6 +94,6 @@ final class IntegrationTests: BaseHazkeyServerTestCase {
     let session2GetQuery = QueryDataBuilder.getComposingString()
     let session2StringResponse = try sendQuery(session2GetQuery)
     XCTAssertEqual(session2StringResponse.status, .success)
-    XCTAssertEqual(session2StringResponse.result, "", "New session should start with empty state")
+    XCTAssertEqual(session2StringResponse.text, "", "New session should start with empty state")
   }
 }

--- a/hazkey-server/Tests/hazkey-server/utils.swift
+++ b/hazkey-server/Tests/hazkey-server/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftGlibc
 import XCTest
 
-@testable import hazkeyServer
+@testable import hazkey_server
 
 // MARK: - Test Configuration
 struct TestConfig {
@@ -14,69 +14,76 @@ struct TestConfig {
 // MARK: - Test Data Builders
 struct QueryDataBuilder {
   static func setConfig(
-    commaStyle: Int32 = 0,
-    numberFullwidth: Int32 = 0,
-    periodStyle: Int32 = 0,
-    spaceFullwidth: Int32 = 0,
-    symbolFullwidth: Int32 = 0,
-    tenCombining: Int32 = 0,
+    numberFullwidth: Bool = true,
+    symbolFullwidth: Bool = true,
     zenzaiEnabled: Bool = false,
     zenzaiInferLimit: Int32 = 1
-  ) -> Hazkey_Commands_QueryData {
-    var query = Hazkey_Commands_QueryData()
-    query.function = .setConfig
-    query.setConfig = Hazkey_Commands_QueryData.SetConfigProps.with {
-      $0.commaStyle = commaStyle
-      $0.numberFullwidth = numberFullwidth
-      $0.periodStyle = periodStyle
-      $0.profileText = ""
-      $0.spaceFullwidth = spaceFullwidth
-      $0.symbolFullwidth = symbolFullwidth
-      $0.tenCombining = tenCombining
-      $0.zenzaiEnabled = zenzaiEnabled
-      $0.zenzaiInferLimit = zenzaiInferLimit
+  ) -> Hazkey_RequestEnvelope {
+    var profile = HazkeyServerConfig.genDefaultConfig()
+    profile.enabledKeymaps.removeAll {
+      (!numberFullwidth && $0.name == "Fullwidth Number")
+        || (!symbolFullwidth && $0.name == "Fullwidth Symbol")
     }
-    return query
+    profile.zenzaiEnable = zenzaiEnabled
+    profile.zenzaiInferLimit = zenzaiInferLimit
+
+    return Hazkey_RequestEnvelope.with {
+      $0.setConfig = Hazkey_Config_SetConfig.with {
+        $0.profiles = [profile]
+      }
+    }
   }
 
-  static func inputText(_ text: String, isDirect: Bool = false) -> Hazkey_Commands_QueryData {
-    var query = Hazkey_Commands_QueryData()
-    query.function = .inputText
-    query.inputText = Hazkey_Commands_QueryData.InputTextProps.with {
-      $0.text = text
-      $0.isDirect = isDirect
+  static func getConfig() -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.getConfig = Hazkey_Config_GetConfig()
     }
-    return query
+  }
+
+  static func inputText(_ text: String) -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.inputChar = Hazkey_Commands_InputChar.with {
+        $0.text = text
+      }
+    }
+  }
+
+  static func modifierEvent(
+    type: Hazkey_Commands_ModifierEvent.ModifierType,
+    event: Hazkey_Commands_ModifierEvent.EventType
+  ) -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.modifierEvent = Hazkey_Commands_ModifierEvent.with {
+        $0.modType = type
+        $0.eventType = event
+      }
+    }
   }
 
   static func getComposingString(
-    charType: Hazkey_Commands_QueryData.GetComposingStringProps.CharType = .hiragana
-  ) -> Hazkey_Commands_QueryData {
-    var query = Hazkey_Commands_QueryData()
-    query.function = .getComposingString
-    query.getComposingString = Hazkey_Commands_QueryData.GetComposingStringProps.with {
-      $0.charType = charType
+    charType: Hazkey_Commands_GetComposingString.CharType = .hiragana,
+    currentPreedit: String = ""
+  ) -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.getComposingString = Hazkey_Commands_GetComposingString.with {
+        $0.charType = charType
+        $0.currentPreedit = currentPreedit
+      }
     }
-    return query
   }
 
-  static func createComposingTextInstance() -> Hazkey_Commands_QueryData {
-    var query = Hazkey_Commands_QueryData()
-    query.function = .createComposingTextInstance
-    return query
+  static func createComposingTextInstance() -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.newComposingText = Hazkey_Commands_NewComposingText()
+    }
   }
 
-  static func getCandidates(
-    nBest: Int32 = 9,
-    isPredictMode: Bool = false
-  ) -> Hazkey_Commands_QueryData {
-    var query = Hazkey_Commands_QueryData()
-    query.function = .getCandidates
-    query.getCandidates = Hazkey_Commands_QueryData.GetCandidatesProps.with {
-      $0.nBest = nBest
-      $0.isPredictMode = isPredictMode
+  static func getCandidates(isSuggest: Bool = false) -> Hazkey_RequestEnvelope {
+    Hazkey_RequestEnvelope.with {
+      $0.getCandidates = Hazkey_Commands_GetCandidates.with {
+        $0.isSuggest = isSuggest
+      }
     }
-    return query
   }
 }
 
@@ -138,7 +145,7 @@ class HazkeyServerClient {
     }
   }
 
-  func sendQuery(_ query: Hazkey_Commands_QueryData) throws -> Hazkey_Commands_ResultData {
+  func sendQuery(_ query: Hazkey_RequestEnvelope) throws -> Hazkey_ResponseEnvelope {
     guard let socket = socket else {
       throw TestError.notConnected
     }
@@ -146,7 +153,7 @@ class HazkeyServerClient {
     let reqData = try query.serializedData()
     let responseData = try sendRequest(reqData, socket: socket)
 
-    return try Hazkey_Commands_ResultData(serializedBytes: responseData)
+    return try Hazkey_ResponseEnvelope(serializedBytes: responseData)
   }
 
   private func sendRequest(_ reqData: Data, socket: Int32) throws -> Data {


### PR DESCRIPTION
## 概要

`hazkey-server/Tests` が削除済みの `Hazkey_Commands_QueryData` / `Hazkey_Commands_ResultData` を参照しており、現行コードではコンパイルできない状態を修正します。

## 変更内容

- テストクライアントを `Hazkey_RequestEnvelope` / `Hazkey_ResponseEnvelope` に移行
- 各リクエストを現行のoneof payloadで生成
- 設定テストを現行のProfile・keymap構成へ更新
- Direct入力を現行のShift modifier eventで検証
- 廃止されたリクエスト単位のnBestテストを、Profileのpage size検証へ更新

## 検証

- Omarchy 4.0.2安定版VM
- Release構成でhazkey全体をCMakeビルド
- `swift test -c release --traits ZenzaiSupport`（hazkey-serverを隔離XDG環境で起動）
- 18 tests / 0 failures

#25 で新規テストを追加する際に既存テストをexcludeする必要がなくなるよう、独立した修正として作成しました。